### PR TITLE
Fixes #66 - sudachitra not being compatible with transformers version newer than 4.34

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ progressbar2~=3.53.1
 tokenizers>=0.10.3
 transformers>=4.6.1
 sudachipy>=0.6.2
-sudachidict_core>=20210802
+sudachidict_core==20210802.*

--- a/sudachitra/tokenization_bert_sudachipy.py
+++ b/sudachitra/tokenization_bert_sudachipy.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Optional, Tuple
 from sudachipy.morpheme import Morpheme
 from transformers.models.bert_japanese.tokenization_bert_japanese import CharacterTokenizer
 from transformers.models.bert.tokenization_bert import WordpieceTokenizer
-from transformers.tokenization_utils import PreTrainedTokenizer
+from transformers.tokenization_utils import AddedToken, PreTrainedTokenizer
 
 from .input_string_normalizer import InputStringNormalizer
 from .sudachipy_word_tokenizer import SudachipyWordTokenizer
@@ -152,22 +152,11 @@ class BertSudachipyTokenizer(PreTrainedTokenizer):
             sudachipy_kwargs=None,
             **kwargs
     ):
-        super().__init__(
-            do_lower_case=do_lower_case,
-            do_nfkc=do_nfkc,
-            do_word_tokenize=do_word_tokenize,
-            do_subword_tokenize=do_subword_tokenize,
-            word_tokenizer_type=word_tokenizer_type,
-            subword_tokenizer_type=subword_tokenizer_type,
-            unk_token=unk_token,
-            sep_token=sep_token,
-            pad_token=pad_token,
-            cls_token=cls_token,
-            mask_token=mask_token,
-            word_form_type=word_form_type,
-            sudachipy_kwargs=sudachipy_kwargs,
-            **kwargs,
-        )
+        unk_token = AddedToken(unk_token, lstrip=False, rstrip=False) if isinstance(unk_token, str) else unk_token
+        sep_token = AddedToken(sep_token, lstrip=False, rstrip=False) if isinstance(sep_token, str) else sep_token
+        pad_token = AddedToken(pad_token, lstrip=False, rstrip=False) if isinstance(pad_token, str) else pad_token
+        cls_token = AddedToken(cls_token, lstrip=False, rstrip=False) if isinstance(cls_token, str) else cls_token
+        mask_token = AddedToken(mask_token, lstrip=False, rstrip=False) if isinstance(mask_token, str) else mask_token
 
         if not os.path.isfile(vocab_file):
             raise ValueError(f"Can't find a vocabulary file at path '{vocab_file}'.")
@@ -189,6 +178,23 @@ class BertSudachipyTokenizer(PreTrainedTokenizer):
         self.word_tokenizer = SudachipyWordTokenizer(**(self.sudachipy_kwargs or {}))
         self.word_form_type = word_form_type
         self.word_formatter = word_formatter(self.word_form_type, self.word_tokenizer.sudachi_dict)
+
+        super().__init__(
+            do_lower_case=do_lower_case,
+            do_nfkc=do_nfkc,
+            do_word_tokenize=do_word_tokenize,
+            do_subword_tokenize=do_subword_tokenize,
+            word_tokenizer_type=word_tokenizer_type,
+            subword_tokenizer_type=subword_tokenizer_type,
+            unk_token=unk_token,
+            sep_token=sep_token,
+            pad_token=pad_token,
+            cls_token=cls_token,
+            mask_token=mask_token,
+            word_form_type=word_form_type,
+            sudachipy_kwargs=sudachipy_kwargs,
+            **kwargs,
+        )
 
         self.do_subword_tokenize = do_subword_tokenize
         self.subword_tokenizer_type = subword_tokenizer_type


### PR DESCRIPTION
## Changes:
Mostly put the call to super.init() at the end of the init
As a result of the super.init() being set at the end after the sub_word_tokenize, the unk_token attribute was not set.
Had changed subword_tokenize behaviour referencing the same change being done in tokenization_bert_japanese as part of change [here](https://github.com/huggingface/transformers/pull/23909/files#diff-1a1e2482dde6b554d418cf503d1a04d4de8d0caf01fcfea12e085042972f45cbL231))
```diff
- self.subword_tokenizer = CharacterTokenizer(vocab=self.vocab, unk_token=self.unk_token)
+ self.subword_tokenizer = CharacterTokenizer(vocab=self.vocab, unk_token=str(unk_token))
```
